### PR TITLE
Configure Travis to build the Go binary before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 
 install:
   - "sudo pip install ."
+  - "go get github.com/spf13/cobra"
 
 script:
   - "go build -o dvol"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ cache:
 
 before_install:
   # Get packaging tools that can use and cache wheels.
-  - "pip install --upgrade pip>=7"
-  - "pip install wheel"
+  - "sudo pip install --upgrade pip>=7"
+  - "sudo pip install wheel"
 
 install:
-  - "pip install ."
+  - "sudo pip install ."
 
 script:
   - "go build -o dvol"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - "go get github.com/spf13/cobra"
 
 script:
-  - "go build dvol.go"
+  - "go build"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - "go get github.com/spf13/cobra"
 
 script:
-  - "go build"
+  - "go build dvol.go"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - "go get github.com/spf13/cobra"
 
 script:
-  - "go build dvol.go -o dvol"
+  - "go build dvol.go"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.
   # https://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-build-on-one-VM
   - "trial -j2 dvol_python"
-  - "TEST_DVOL_BINARY=1 trial -j2 dvol_python"
+  - "TEST_DVOL_BINARY=1 DVOL_BINARY=$PWD/dvol trial -j2 dvol_python"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ notifications:
     # See Travis in the Slack App directory for details.
     secure: "IuMdO5YgVlYdq12I8PbrnjgQo2mpW53LoABUHoHFnaczpXmOD0cbgSX4YRRqGPTkBj3iMqOYtGbOtcyIRwLB9SVbr2xeDpvRYC8auX/jGMbQmaQMhG4kZOpVA9FKt+XcJFj6lsihT50tx2uJ4zn85KjOy1ZJQjgpka+vsKJbvGAg65AvCovlB/l1fyd8eaRZxDXyvapD7I39R7ij22r/QfnJ0t2JT0PKS0SR+gPemnjMhGkW0n3dyoOOkhqVAEyevt6f+s8NNnSioCuJy6X9R6eIXOeJYXHMvigxpZ7nEnrWik3IgQ9+rqJjjqzb9paxU+1+aQP0gb+r1M+hfbGyWQp1k6KCNb1IljCtjNccWxlajkooLJS1haRKiyV96U+DiDybpVIbEdtNMBQrRN+6lCbU8OduHxluH5WnAdZEUGz6pQLt7fxCazKzib/vxnUlSgvRnKzweYd21zj3c4w6aPLdCaI2eQM036Zwt/9ltWbk5I8sjAWfCgvWqxD+MaOT2vAog8T7B8WoyRjhbChtMNNHtw64a9W402WADrQO1jTU4tGsKwDbjXb4j2GtvhKahrGGigFYBfPLgOi8mzzwaJh7uBo/S8evAG/K/abc2hhhLBGWlSiA252hbNcgjGk8QuwKFhaA1DenAXZTf8GcwYC+ZlmKOczIujamQKfAvjM="
 
-language: python
-python: 2.7
-sudo: false
+language: go
+go: 1.6
+sudo: required
 
 cache:
   directories:
@@ -25,6 +25,7 @@ install:
   - "pip install ."
 
 script:
+  "go build -o dvol"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - "go get github.com/spf13/cobra"
 
 script:
-  - "go build -o dvol"
+  - "go build dvol.go -o dvol"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
   - "go get github.com/spf13/cobra"
-  - "go build dvol.go"
+  - "go build ."
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - "pip install ."
 
 script:
-  "go build -o dvol"
+  - "go build -o dvol"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ before_install:
 
 install:
   - "sudo pip install ."
-  - "go get github.com/spf13/cobra"
 
 script:
+  - "go get github.com/spf13/cobra"
   - "go build dvol.go"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
   - "go get github.com/spf13/cobra"
-  - "go build dvol.go"
+  - "go build"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
   - "go get github.com/spf13/cobra"
-  - "go build ."
+  - "go build dvol.go"
   # Run the unit test suite using trial.
   # Let the runner parallelise the tests a little bit.
   # Travis CI docs suggest you have between 1 and 2 CPUs to use.

--- a/dvol.go
+++ b/dvol.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "./cmd"
-//    "github.com/clusterhq/dvol/dockercontainers"
-//    "github.com/clusterhq/dvol/plugin"
+	"fmt"
+	"github.com/ClusterHQ/dvol/cmd"
+	"os"
+	//    "github.com/clusterhq/dvol/dockercontainers"
+	//    "github.com/clusterhq/dvol/plugin"
 )
 
 func main() {
-    if err := cmd.RootCmd.Execute(); err != nil {
-        fmt.Println(err)
-        os.Exit(-1)
-    }
+	if err := cmd.RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 }

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -15,6 +15,7 @@ import subprocess
 import os
 
 TEST_DVOL_BINARY = os.environ.get("TEST_DVOL_BINARY", False)
+DVOL_BINARY = os.environ.get("DVOL_BINARY", "./dvol")
 ARGS = ["--disable-docker-integration"]
 
 if TEST_DVOL_BINARY:
@@ -39,7 +40,7 @@ if TEST_DVOL_BINARY:
 
         def parseOptions(self, args):
             result = subprocess.check_output(
-                ["../dvol"] + args,
+                [DVOL_BINARY] + args,
                 stderr=subprocess.STDOUT
             )
             result = result[:-1]


### PR DESCRIPTION
This change modifies the Travis configuration to build the go binary and then pass the location of the resulting binary to the existing tests.

This change also required the relative imports to be be removed. I've spoken to @mdevilliers about this and he has some ideas about how we move forward from this point to ensure that the project can be forked correctly and can be built correctly on dev machines.

`dvol.go` has also been formatted using `go fmt`.