### PR TITLE
[FLOC-4239] Enable testing of golang binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 test: build
 	. venv/bin/activate \
 	HYPOTHESIS_PROFILE=ci trial dvol_python \
-	&& HYPOTHESIS_PROFILE=ci TEST_DVOL_BINARY=1 DVOL_BINARY=$(PWD)/dvol trial -j2 dvol_python \
+	&& HYPOTHESIS_PROFILE=ci TEST_DVOL_BINARY=1 DVOL_BINARY=$(PWD)/dvol trial dvol_python \
 	&& scripts/verify-tests.sh
 
 # 'verify' ensures your golang code passes 'the basics'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 test: build
 	. venv/bin/activate \
 	HYPOTHESIS_PROFILE=ci trial dvol_python \
-	&& HYPOTHESIS_PROFILE=ci DVOL_BINARY=$PWD/dvol trial -j2 dvol_python \
+	&& HYPOTHESIS_PROFILE=ci TEST_DVOL_BINARY=1 DVOL_BINARY=$(PWD)/dvol trial -j2 dvol_python \
 	&& scripts/verify-tests.sh
 
 # 'verify' ensures your golang code passes 'the basics'


### PR DESCRIPTION
Fixes [FLOC-4239](https://clusterhq.atlassian.net/browse/FLOC-4239).

The `test` target in the Makefile is missing the setting of the environment variable `TEST_DVOL_BINARY`. This is required to enable testing of the external version of dvol.

Also, it was previously noted that tests which use `hypothesis` shouldn't be run in parallel so remove the `-j2` flag from the `trial` command.