### PR TITLE
[FLOC-4239] Run tests for both Python and Golang implementations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 # 'test' will run the python tests using the dvol cli
 test: build
 	. venv/bin/activate \
-	HYPOTHESIS_PROFILE=ci trial dvol_python \
+	&& HYPOTHESIS_PROFILE=ci trial dvol_python \
 	&& HYPOTHESIS_PROFILE=ci TEST_DVOL_BINARY=1 DVOL_BINARY=$(PWD)/dvol trial dvol_python \
 	&& scripts/verify-tests.sh
 


### PR DESCRIPTION
The previous fix for [FLOC-4239](https://clusterhq.atlassian.net/browse/FLOC-4239) resulted in only the tests for the Golang version being run, not both sets as was intended.

Fix the Makefile so that both `trial` commands are run.