### PR TITLE
[FLOC-4153] Initial support for `dvol rm` in go

### DIFF
--- a/dvol_python/dvol.py
+++ b/dvol_python/dvol.py
@@ -61,6 +61,8 @@ class EmptyContainers(object):
     def get_related_containers(self, volume):
         return []
 
+    def remove_related_containers(self, volume):
+        pass
 
 class NullLock(object):
     containers = EmptyContainers()
@@ -201,6 +203,7 @@ class Voluminous(object):
         if not self._directory.child(volume).exists():
             raise UsageError("Volume %r does not exist, cannot remove it" %
                     (volume,))
+        import pdb; pdb.set_trace()
         containers = self.lock.containers.get_related_containers(volume)
         if containers:
             raise UsageError("Cannot remove %r while it is in use by '%s'" %

--- a/dvol_python/dvol.py
+++ b/dvol_python/dvol.py
@@ -199,16 +199,15 @@ class Voluminous(object):
         self.output("Created volume %s" % (name,))
         self.createBranch(name, DEFAULT_BRANCH)
 
-    def removeVolume(self, volume):
+    def removeVolume(self, volume, force=False):
         if not self._directory.child(volume).exists():
             raise UsageError("Volume %r does not exist, cannot remove it" %
                     (volume,))
-        import pdb; pdb.set_trace()
         containers = self.lock.containers.get_related_containers(volume)
         if containers:
             raise UsageError("Cannot remove %r while it is in use by '%s'" %
                     (volume, (",".join(c['Name'] for c in containers))))
-        if self._userIsSure("This will remove all containers using the volume"):
+        if force or self._userIsSure("This will remove all containers using the volume"):
             self.output("Deleting volume %r" % (volume,))
             # Remove related containers
             self.lock.containers.remove_related_containers(volume)
@@ -571,11 +570,18 @@ class RemoveOptions(Options):
     """
     Entirely destroy a volume.
     """
+    optFlags = [
+        ["force", "f", "Force remove"],
+        ]
+
+    synopsis = "<force>"
+    
     def parseArgs(self, volume):
         self.volume = volume
 
     def run(self, voluminous):
-        voluminous.removeVolume(self.volume)
+        import pdb; pdb.set_trace()
+        voluminous.removeVolume(self.volume, force=self["force"])
 
 class VoluminousOptions(Options):
     """

--- a/dvol_python/dvol.py
+++ b/dvol_python/dvol.py
@@ -200,9 +200,13 @@ class Voluminous(object):
         self.createBranch(name, DEFAULT_BRANCH)
 
     def removeVolume(self, volume, force=False):
-        if not self._directory.child(volume).exists():
-            self.output("Volume %r does not exist, cannot remove it" %
-                    (volume,))
+        try:
+            if not self._directory.child(volume).exists():
+                self.output("Volume %r does not exist, cannot remove it" %
+                        (volume,))
+                return
+        except InsecurePath:
+            self.output("Error: %s is not a valid name" % (volume,))
             return
         containers = self.lock.containers.get_related_containers(volume)
         if containers:

--- a/dvol_python/dvol.py
+++ b/dvol_python/dvol.py
@@ -201,8 +201,9 @@ class Voluminous(object):
 
     def removeVolume(self, volume, force=False):
         if not self._directory.child(volume).exists():
-            raise UsageError("Volume %r does not exist, cannot remove it" %
+            self.output("Volume %r does not exist, cannot remove it" %
                     (volume,))
+            return
         containers = self.lock.containers.get_related_containers(volume)
         if containers:
             raise UsageError("Cannot remove %r while it is in use by '%s'" %

--- a/dvol_python/dvol.py
+++ b/dvol_python/dvol.py
@@ -580,7 +580,6 @@ class RemoveOptions(Options):
         self.volume = volume
 
     def run(self, voluminous):
-        import pdb; pdb.set_trace()
         voluminous.removeVolume(self.volume, force=self["force"])
 
 class VoluminousOptions(Options):

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -478,7 +478,6 @@ class VoluminousTests(TestCase):
         self.assertIn("Volume 'foo' does not exist, cannot remove it", output)
         self.assertFalse(self.tmpdir.child("foo").exists())
 
-    @skip_if_go_version
     def test_remove_volume_path_separator(self):
         dvol = VoluminousOptions()
         try:

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -478,7 +478,7 @@ class VoluminousTests(TestCase):
         self.assertFalse(self.tmpdir.child("foo").exists())
     
     @skip_if_go_version
-    def test_remove_volume_invalid_name(self):
+    def test_remove_volume_path_separator(self):
         dvol = VoluminousOptions()
         try:
             dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo/bar"])

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -460,6 +460,7 @@ class VoluminousTests(TestCase):
         self.assertTrue(volume.child("commits").child(oldCommit).exists())
         self.assertTrue(volume.child("commits").child(newCommit).exists())
 
+    @skip_if_go_version
     def test_remove_volume(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
@@ -468,6 +469,7 @@ class VoluminousTests(TestCase):
             "Deleting volume 'foo'")
         self.assertFalse(self.tmpdir.child("foo").exists())
     
+    @skip_if_go_version
     def test_remove_volume_does_not_exist(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo"])
@@ -475,6 +477,7 @@ class VoluminousTests(TestCase):
             "Volume 'foo' does not exist, cannot remove it")
         self.assertFalse(self.tmpdir.child("foo").exists())
     
+    @skip_if_go_version
     def test_remove_volume_invalid_name(self):
         dvol = VoluminousOptions()
         try:

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -468,12 +468,14 @@ class VoluminousTests(TestCase):
             "Deleting volume 'foo'")
         self.assertFalse(self.tmpdir.child("foo").exists())
 
-    @skip_if_go_version
     def test_remove_volume_does_not_exist(self):
         dvol = VoluminousOptions()
-        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo"])
-        self.assertEqual(dvol.voluminous.getOutput()[-1],
-            "Volume 'foo' does not exist, cannot remove it")
+        try:
+            dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo"])
+            output = dvol.voluminous.getOutput()[-1]
+        except CalledProcessErrorWithOutput, error:
+            output = error.original.output
+        self.assertIn("Volume 'foo' does not exist, cannot remove it", output)
         self.assertFalse(self.tmpdir.child("foo").exists())
 
     @skip_if_go_version

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -460,7 +460,6 @@ class VoluminousTests(TestCase):
         self.assertTrue(volume.child("commits").child(oldCommit).exists())
         self.assertTrue(volume.child("commits").child(newCommit).exists())
 
-    @skip_if_go_version
     def test_remove_volume(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
@@ -468,7 +467,7 @@ class VoluminousTests(TestCase):
         self.assertEqual(dvol.voluminous.getOutput()[-1],
             "Deleting volume 'foo'")
         self.assertFalse(self.tmpdir.child("foo").exists())
-    
+
     @skip_if_go_version
     def test_remove_volume_does_not_exist(self):
         dvol = VoluminousOptions()
@@ -476,7 +475,7 @@ class VoluminousTests(TestCase):
         self.assertEqual(dvol.voluminous.getOutput()[-1],
             "Volume 'foo' does not exist, cannot remove it")
         self.assertFalse(self.tmpdir.child("foo").exists())
-    
+
     @skip_if_go_version
     def test_remove_volume_path_separator(self):
         dvol = VoluminousOptions()

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -477,7 +477,10 @@ class VoluminousTests(TestCase):
     
     def test_remove_volume_invalid_name(self):
         dvol = VoluminousOptions()
-        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo/bar"])
-        self.assertEqual(dvol.voluminous.getOutput()[-1],
-            "Volume 'foo' does not exist, cannot remove it")
-        self.assertFalse(self.tmpdir.child("foo").exists())
+        try:
+            dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo/bar"])
+            output = dvol.voluminous.getOutput()[-1]
+        except CalledProcessErrorWithOutput, error:
+            output = error.original.output
+        self.assertIn("Error", output)
+        self.assertIn("foo/bar", output)

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -459,3 +459,25 @@ class VoluminousTests(TestCase):
         # new still exists because it's referenced in another branch
         self.assertTrue(volume.child("commits").child(oldCommit).exists())
         self.assertTrue(volume.child("commits").child(newCommit).exists())
+
+    def test_remove_volume(self):
+        dvol = VoluminousOptions()
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo"])
+        self.assertEqual(dvol.voluminous.getOutput()[-1],
+            "Deleting volume 'foo'")
+        self.assertFalse(self.tmpdir.child("foo").exists())
+    
+    def test_remove_volume_does_not_exist(self):
+        dvol = VoluminousOptions()
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo"])
+        self.assertEqual(dvol.voluminous.getOutput()[-1],
+            "Volume 'foo' does not exist, cannot remove it")
+        self.assertFalse(self.tmpdir.child("foo").exists())
+    
+    def test_remove_volume_invalid_name(self):
+        dvol = VoluminousOptions()
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "rm", "-f", "foo/bar"])
+        self.assertEqual(dvol.voluminous.getOutput()[-1],
+            "Volume 'foo' does not exist, cannot remove it")
+        self.assertFalse(self.tmpdir.child("foo").exists())

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -25,8 +25,9 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 }
 
 func initVolume(cmd *cobra.Command, args []string, out io.Writer) error {
-	if len(args) == 0 {
-		return fmt.Errorf("Please specify a volume name.")
+	err := checkVolumeArgs(args)
+	if err != nil {
+		return err
 	}
 	volumeName := args[0]
 	if !datalayer.ValidVolumeName(volumeName) {
@@ -35,7 +36,7 @@ func initVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 	if datalayer.VolumeExists(basePath, volumeName) {
 		return fmt.Errorf("Error: volume " + volumeName + " already exists")
 	}
-	err := datalayer.CreateVolume(basePath, volumeName)
+	err = datalayer.CreateVolume(basePath, volumeName)
 	if err != nil {
 		return fmt.Errorf("Error creating volume")
 	}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ClusterHQ/dvol/pkg/datalayer"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdInit() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create a volume and its default master branch, then switch to it",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				fmt.Println("Please specify a volume name.")
+				os.Exit(1)
+			}
+			volumeName := args[0]
+			if !datalayer.ValidVolumeName(volumeName) {
+				fmt.Println("Error: " + volumeName + " is not a valid name")
+				os.Exit(1)
+			}
+			if datalayer.VolumeExists(basePath, volumeName) {
+				fmt.Println("Error: volume " + volumeName + " already exists")
+				os.Exit(1)
+			}
+			err := datalayer.CreateVolume(basePath, volumeName)
+			if err != nil {
+				fmt.Println("Error creating volume")
+				os.Exit(1)
+			}
+			fmt.Println("Created volume", volumeName)
+
+			err = datalayer.CreateVariant(basePath, volumeName, "master")
+			if err != nil {
+				fmt.Println("Error creating branch")
+				os.Exit(1)
+			}
+			fmt.Println("Created branch " + volumeName + "/master")
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/rm.go
+++ b/pkg/cmd/rm.go
@@ -29,7 +29,6 @@ func NewCmdRm(out io.Writer) *cobra.Command {
 }
 
 func removeVolume(cmd *cobra.Command, args []string, out io.Writer) error {
-
 	err := checkVolumeArgs(args)
 	if err != nil {
 		return err

--- a/pkg/cmd/rm.go
+++ b/pkg/cmd/rm.go
@@ -50,6 +50,9 @@ func removeVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) == 0 {
 		return fmt.Errorf("Please specify a volume name.")
 	}
+	if len(args) > 1 {
+		return fmt.Errorf("Wrong number of arguments.")
+	}
 	volumeName := args[0]
 	if !datalayer.ValidVolumeName(volumeName) {
 		return fmt.Errorf("Error: " + volumeName + " is not a valid name")

--- a/pkg/cmd/rm.go
+++ b/pkg/cmd/rm.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ClusterHQ/dvol/pkg/datalayer"
+	"github.com/spf13/cobra"
+)
+
+var forceRemoveVolume bool
+
+func userIsSure(extraMessage string) bool {
+	message := fmt.Sprintf("Are you sure? %s (y/n): ", extraMessage)
+	fmt.Print(message)
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		fmt.Println("Error reading response.")
+		return false
+	}
+	response = strings.ToLower(response)
+	if response == "y" || response == "yes" {
+		return true
+	}
+	return false
+}
+
+func NewCmdRm() *cobra.Command {
+	cmd := &cobra.Command{
+		// TODO: Improve the usage string to include a volume name to remove
+		Use:   "rm",
+		Short: "Destroy a dvol volume",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				fmt.Println("Please specify a volume name.")
+				os.Exit(1)
+			}
+			volumeName := args[0]
+			if !datalayer.ValidVolumeName(volumeName) {
+				fmt.Println("Error: " + volumeName + " is not a valid name")
+				os.Exit(1)
+			}
+			if !datalayer.VolumeExists(basePath, volumeName) {
+				msg := fmt.Sprintf("Volume '%s' does not exist, cannot remove it", volumeName)
+				fmt.Println(msg)
+				os.Exit(1)
+			}
+			if forceRemoveVolume || userIsSure("This will remove all containers using the volume") {
+				s := fmt.Sprintf("Deleting volume '%s'", volumeName)
+				fmt.Println(s)
+				err := datalayer.RemoveVolume(basePath, volumeName)
+				if err != nil {
+					fmt.Println("Error removing volume")
+					os.Exit(1)
+				}
+			} else {
+				fmt.Println("Aborting.")
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&forceRemoveVolume, "force", "f", false, "Force remove")
+	return cmd
+}

--- a/pkg/cmd/rm.go
+++ b/pkg/cmd/rm.go
@@ -60,13 +60,13 @@ func removeVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 	}
 	if forceRemoveVolume || userIsSure("This will remove all containers using the volume") {
 		s := fmt.Sprintf("Deleting volume '%s'", volumeName)
-		fmt.Println(out, s)
+		fmt.Fprintln(out, s)
 		err := datalayer.RemoveVolume(basePath, volumeName)
 		if err != nil {
 			return fmt.Errorf("Error removing volume")
 		}
 	} else {
-		fmt.Println(out, "Aborting.")
+		fmt.Fprintln(out, "Aborting.")
 	}
 	return nil
 }

--- a/pkg/cmd/rm_test.go
+++ b/pkg/cmd/rm_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestRmNoArgs(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdRm(buf)
+	err := removeVolume(cmd, []string{}, buf)
+	if err == nil {
+		t.Error("Expected error result with no arguments")
+	}
+	expected := "Please specify a volume name."
+	if err.Error() != expected {
+		t.Errorf("Expected: %s Actual: %s", expected, err.Error())
+	}
+}
+
+func TestRmInvalidVolumeName(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdRm(buf)
+	err := removeVolume(cmd, []string{"foo/bar"}, buf)
+	if err == nil {
+		t.Error("Expected error result with invalid volume name")
+	}
+	expected := "Error: foo/bar is not a valid name"
+	if err.Error() != expected {
+		t.Errorf("Expected: %s Actual: %s", expected, err.Error())
+	}
+}
+
+func TestRmVolumeDoesNotExist(t *testing.T) {
+	// Setup
+	originalBasePath := basePath
+	dir, _ := ioutil.TempDir("", "test")
+	basePath = dir
+
+	// Test
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdRm(buf)
+	err := removeVolume(cmd, []string{"foo"}, buf)
+	if err == nil {
+		t.Error("Expected error result with non-existent volume")
+	}
+
+	expected := "Volume 'foo' does not exist, cannot remove it"
+	if err.Error() != expected {
+		t.Errorf("Expected: %s Actual: %s", expected, err.Error())
+	}
+
+	// Teardown
+	basePath = originalBasePath
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +26,7 @@ func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
 	RootCmd.AddCommand(NewCmdInit())
-	RootCmd.AddCommand(NewCmdRm())
+	RootCmd.AddCommand(NewCmdRm(os.Stdin))
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/ClusterHQ/dvol/pkg/datalayer"
 	"github.com/spf13/cobra"
 )
 
@@ -24,41 +22,12 @@ running on your laptop so you can easily save a particular state
 and come back to it later.`,
 }
 
-var cmdSwitch = &cobra.Command{
-	Use:   "switch",
-	Short: "Switch active volume for commands below (commit, log etc)",
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("Please specify a volume name.")
-			os.Exit(1)
-		}
-		if len(args) > 1 {
-			fmt.Println("Wrong number of arguments.")
-			os.Exit(1)
-		}
-		volumeName := args[0]
-		if !datalayer.ValidVolumeName(volumeName) {
-			fmt.Println("Error: " + volumeName + " is not a valid name")
-			os.Exit(1)
-		}
-		if !datalayer.VolumeExists(basePath, volumeName) {
-			fmt.Println("Error: " + volumeName + " does not exist")
-			os.Exit(1)
-		}
-		err := datalayer.SwitchVolume(basePath, volumeName)
-		if err != nil {
-			fmt.Println("Error switching volume")
-			os.Exit(1)
-		}
-	},
-}
-
 func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
 	RootCmd.AddCommand(NewCmdInit())
 	RootCmd.AddCommand(NewCmdRm(os.Stdout))
-	RootCmd.AddCommand(cmdSwitch)
+	RootCmd.AddCommand(NewCmdSwitch())
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ClusterHQ/dvol/pkg/datalayer"
 	"github.com/spf13/cobra"
@@ -77,14 +78,34 @@ var cmdRm = &cobra.Command{
 			fmt.Println(msg)
 			os.Exit(1)
 		}
-		err := datalayer.RemoveVolume(basePath, volumeName)
-		if err != nil {
-			fmt.Println("Error removing volume")
-			os.Exit(1)
+		if forceRemoveVolume || userIsSure("This will remove all containers using the volume") {
+			s := fmt.Sprintf("Deleting volume '%s'", volumeName)
+			fmt.Println(s)
+			err := datalayer.RemoveVolume(basePath, volumeName)
+			if err != nil {
+				fmt.Println("Error removing volume")
+				os.Exit(1)
+			}
+		} else {
+			fmt.Println("Aborting.")
 		}
-		s := fmt.Sprintf("Deleting volume '%s'", volumeName)
-		fmt.Println(s)
 	},
+}
+
+func userIsSure(extraMessage string) bool {
+	message := fmt.Sprintf("Are you sure? %s (y/n): ", extraMessage)
+	fmt.Print(message)
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		fmt.Println("Error reading response.")
+		return false
+	}
+	response = strings.ToLower(response)
+	if response == "y" || response == "yes" {
+		return true
+	}
+	return false
 }
 
 func init() {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,9 +25,9 @@ and come back to it later.`,
 func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
-	RootCmd.AddCommand(NewCmdInit())
+	RootCmd.AddCommand(NewCmdInit(os.Stdout))
 	RootCmd.AddCommand(NewCmdRm(os.Stdout))
-	RootCmd.AddCommand(NewCmdSwitch())
+	RootCmd.AddCommand(NewCmdSwitch(os.Stdout))
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/ClusterHQ/dvol/pkg/datalayer"
 	"github.com/spf13/cobra"
@@ -12,7 +11,6 @@ import (
 var basePath string
 var echoTimes int
 var disableDockerIntegration bool
-var forceRemoveVolume bool
 
 const DEFAULT_BRANCH string = "master"
 
@@ -59,61 +57,11 @@ var cmdInit = &cobra.Command{
 	},
 }
 
-var cmdRm = &cobra.Command{
-	// TODO: Improve the usage string to include a volume name to remove
-	Use:   "rm",
-	Short: "Destroy a dvol volume",
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("Please specify a volume name.")
-			os.Exit(1)
-		}
-		volumeName := args[0]
-		if !datalayer.ValidVolumeName(volumeName) {
-			fmt.Println("Error: " + volumeName + " is not a valid name")
-			os.Exit(1)
-		}
-		if !datalayer.VolumeExists(basePath, volumeName) {
-			msg := fmt.Sprintf("Volume '%s' does not exist, cannot remove it", volumeName)
-			fmt.Println(msg)
-			os.Exit(1)
-		}
-		if forceRemoveVolume || userIsSure("This will remove all containers using the volume") {
-			s := fmt.Sprintf("Deleting volume '%s'", volumeName)
-			fmt.Println(s)
-			err := datalayer.RemoveVolume(basePath, volumeName)
-			if err != nil {
-				fmt.Println("Error removing volume")
-				os.Exit(1)
-			}
-		} else {
-			fmt.Println("Aborting.")
-		}
-	},
-}
-
-func userIsSure(extraMessage string) bool {
-	message := fmt.Sprintf("Are you sure? %s (y/n): ", extraMessage)
-	fmt.Print(message)
-	var response string
-	_, err := fmt.Scanln(&response)
-	if err != nil {
-		fmt.Println("Error reading response.")
-		return false
-	}
-	response = strings.ToLower(response)
-	if response == "y" || response == "yes" {
-		return true
-	}
-	return false
-}
-
 func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
 	RootCmd.AddCommand(cmdInit)
-	RootCmd.AddCommand(cmdRm)
-	cmdRm.Flags().BoolVarP(&forceRemoveVolume, "force", "f", false, "Force remove")
+	RootCmd.AddCommand(NewCmdRm())
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -73,7 +73,8 @@ var cmdRm = &cobra.Command{
 			os.Exit(1)
 		}
 		if !datalayer.VolumeExists(basePath, volumeName) {
-			fmt.Println("Error: volume " + volumeName + " does not exist")
+			msg := fmt.Sprintf("Volume '%s' does not exist, cannot remove it", volumeName)
+			fmt.Println(msg)
 			os.Exit(1)
 		}
 		err := datalayer.RemoveVolume(basePath, volumeName)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
 	RootCmd.AddCommand(NewCmdInit())
-	RootCmd.AddCommand(NewCmdRm(os.Stdin))
+	RootCmd.AddCommand(NewCmdRm(os.Stdout))
 	RootCmd.AddCommand(cmdSwitch)
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/ClusterHQ/dvol/pkg/datalayer"
 	"github.com/spf13/cobra"
 )
 
@@ -24,43 +20,10 @@ running on your laptop so you can easily save a particular state
 and come back to it later.`,
 }
 
-var cmdInit = &cobra.Command{
-	Use:   "init",
-	Short: "Create a volume and its default master branch, then switch to it",
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("Please specify a volume name.")
-			os.Exit(1)
-		}
-		volumeName := args[0]
-		if !datalayer.ValidVolumeName(volumeName) {
-			fmt.Println("Error: " + volumeName + " is not a valid name")
-			os.Exit(1)
-		}
-		if datalayer.VolumeExists(basePath, volumeName) {
-			fmt.Println("Error: volume " + volumeName + " already exists")
-			os.Exit(1)
-		}
-		err := datalayer.CreateVolume(basePath, volumeName)
-		if err != nil {
-			fmt.Println("Error creating volume")
-			os.Exit(1)
-		}
-		fmt.Println("Created volume", volumeName)
-
-		err = datalayer.CreateVariant(basePath, volumeName, "master")
-		if err != nil {
-			fmt.Println("Error creating branch")
-			os.Exit(1)
-		}
-		fmt.Println("Created branch " + volumeName + "/master")
-	},
-}
-
 func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
-	RootCmd.AddCommand(cmdInit)
+	RootCmd.AddCommand(NewCmdInit())
 	RootCmd.AddCommand(NewCmdRm())
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -24,7 +24,7 @@ running on your laptop so you can easily save a particular state
 and come back to it later.`,
 }
 
-var cmdTimes = &cobra.Command{
+var cmdInit = &cobra.Command{
 	Use:   "init",
 	Short: "Create a volume and its default master branch, then switch to it",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -60,7 +60,7 @@ var cmdTimes = &cobra.Command{
 func init() {
 	// cobra.OnInitialize(initConfig)
 	// TODO support: dvol -p <custom_path> init <volume_name>
-	RootCmd.AddCommand(cmdTimes)
+	RootCmd.AddCommand(cmdInit)
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ClusterHQ/dvol/pkg/datalayer"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSwitch() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "switch",
+		Short: "Switch active volume for commands below (commit, log etc)",
+		Run: func(cmd *cobra.Command, args []string) {
+			switchVolume(cmd, args, os.Stdout)
+		},
+	}
+	return cmd
+}
+
+func switchVolume(cmd *cobra.Command, args []string, out io.Writer) error {
+
+	if len(args) == 0 {
+		fmt.Println("Please specify a volume name.")
+		os.Exit(1)
+	}
+	if len(args) > 1 {
+		fmt.Println("Wrong number of arguments.")
+		os.Exit(1)
+	}
+	volumeName := args[0]
+	if !datalayer.ValidVolumeName(volumeName) {
+		fmt.Println("Error: " + volumeName + " is not a valid name")
+		os.Exit(1)
+	}
+	if !datalayer.VolumeExists(basePath, volumeName) {
+		fmt.Println("Error: " + volumeName + " does not exist")
+		os.Exit(1)
+	}
+	err := datalayer.SwitchVolume(basePath, volumeName)
+	if err != nil {
+		fmt.Println("Error switching volume")
+		os.Exit(1)
+	}
+	return nil
+}

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -25,7 +25,6 @@ func NewCmdSwitch(out io.Writer) *cobra.Command {
 }
 
 func switchVolume(cmd *cobra.Command, args []string, out io.Writer) error {
-
 	err := checkVolumeArgs(args)
 	if err != nil {
 		return err

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -26,11 +26,9 @@ func NewCmdSwitch(out io.Writer) *cobra.Command {
 
 func switchVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 
-	if len(args) == 0 {
-		return fmt.Errorf("Please specify a volume name.")
-	}
-	if len(args) > 1 {
-		return fmt.Errorf("Wrong number of arguments.")
+	err := checkVolumeArgs(args)
+	if err != nil {
+		return err
 	}
 	volumeName := args[0]
 	if !datalayer.ValidVolumeName(volumeName) {
@@ -39,7 +37,7 @@ func switchVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 	if !datalayer.VolumeExists(basePath, volumeName) {
 		return fmt.Errorf("Error: " + volumeName + " does not exist")
 	}
-	err := datalayer.SwitchVolume(basePath, volumeName)
+	err = datalayer.SwitchVolume(basePath, volumeName)
 	if err != nil {
 		return fmt.Errorf("Error switching volume")
 	}

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+func checkVolumeArgs(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("Please specify a volume name.")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("Wrong number of arguments.")
+	}
+	return nil
+}
+
+func userIsSure(extraMessage string) bool {
+	message := fmt.Sprintf("Are you sure? %s (y/n): ", extraMessage)
+	fmt.Print(message)
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		fmt.Println("Error reading response.")
+		return false
+	}
+	response = strings.ToLower(response)
+	if response == "y" || response == "yes" {
+		return true
+	}
+	return false
+}

--- a/pkg/datalayer/datalayer.go
+++ b/pkg/datalayer/datalayer.go
@@ -27,6 +27,11 @@ func CreateVolume(basePath string, volumeName string) error {
 	return os.MkdirAll(volumePath, 0777) // XXX SEC
 }
 
+func RemoveVolume(basePath string, volumeName string) error {
+	volumePath := filepath.FromSlash(basePath + "/" + volumeName)
+	return os.RemoveAll(volumePath)
+}
+
 func CreateVariant(basePath, volumeName, variantName string) error {
 	// XXX Variants are meant to be tagged commits???
 	variantPath := filepath.FromSlash(basePath + "/" + volumeName + "/branches/master")


### PR DESCRIPTION
This adds some initial support for `dvol rm` in the golang implementation with tests provided by @brendan-donegan. Unlike the python version, this change does not include docker integration support.

As part of this change, I've also moved the `rm` and `init` commands into separate files to aid testing of these commands.