### PR TITLE
Ignore the virtualenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_trial_temp/
 .hypothesis/
+venv/
 *.pyc
 *.egg-info
 


### PR DESCRIPTION
Ignore the `venv` directory created during development environment setup.