### PR TITLE
[VOL-84] Docker containers stopped started

### DIFF
--- a/cmd/memorydiskserver/memorydiskserver.go
+++ b/cmd/memorydiskserver/memorydiskserver.go
@@ -37,9 +37,9 @@ $ curl -sSL http://localhost/get
 */
 
 import (
-	"net/http"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 )
 

--- a/cmd/memorydiskserver/memorydiskserver.go
+++ b/cmd/memorydiskserver/memorydiskserver.go
@@ -37,9 +37,13 @@ $ curl -sSL http://localhost/get
 */
 
 import (
-	"fmt"
 	"net/http"
+	"fmt"
+	"io/ioutil"
+	"os"
 )
+
+const STORE = "/data/memorydiskserver.dat"
 
 var theValue string
 
@@ -49,6 +53,14 @@ func getHandler(w http.ResponseWriter, r *http.Request) {
 
 func setHandler(w http.ResponseWriter, r *http.Request) {
 	theValue = r.URL.Query()["value"][0]
+	err := writeValueToDisk()
+	if err != nil {
+		http.Error(w, fmt.Sprintln(err), 500)
+	}
+}
+
+func writeValueToDisk() error {
+	return ioutil.WriteFile(STORE, []byte(theValue), 0600)
 }
 
 //func setHandler(w http.ResponseWriter, r *http.Request) {
@@ -63,6 +75,15 @@ func setHandler(w http.ResponseWriter, r *http.Request) {
 //}
 
 func main() {
+	// Read the starting value
+	dat, err := ioutil.ReadFile(STORE)
+	if err != nil {
+		f, _ := os.Create(STORE)
+		f.Close()
+		dat, _ = ioutil.ReadFile(STORE)
+	}
+	theValue = string(dat)
+
 	http.HandleFunc("/get", getHandler)
 	http.HandleFunc("/set", setHandler)
 

--- a/cmd/memorydiskserver/memorydiskserver.go
+++ b/cmd/memorydiskserver/memorydiskserver.go
@@ -55,7 +55,7 @@ func setHandler(w http.ResponseWriter, r *http.Request) {
 	theValue = r.URL.Query()["value"][0]
 	err := writeValueToDisk()
 	if err != nil {
-		http.Error(w, fmt.Sprintln(err), 500)
+		http.Error(w, fmt.Sprintln(err), http.StatusInternalServerError)
 	}
 }
 

--- a/dvol_python/test_plugin.py
+++ b/dvol_python/test_plugin.py
@@ -171,6 +171,7 @@ class VoluminousTests(TestCase):
             "http://%s:8080/get" % (docker_host(),)
         )).content
 
+    @skip_if_go_version
     def test_switch_branches_restarts_containers(self):
         """
         Docker containers are restarted when switching branches.
@@ -178,11 +179,14 @@ class VoluminousTests(TestCase):
         self.cleanup_memorydiskserver()
         self.start_memorydiskserver()
 
-        run([DVOL, "branch", "alpha"])
+        # We have to do an initial state commit before we can switch branches
+        run([DVOL, "commit", "-m", "Initial"])
+
+        run([DVOL, "checkout", "-b", "alpha"])
         self.try_set_memorydiskserver_value("alpha")
         run([DVOL, "commit", "-m", "alpha"])
 
-        run([DVOL, "branch", "beta"])
+        run([DVOL, "checkout", "-b", "beta"])
         self.try_set_memorydiskserver_value("beta")
         run([DVOL, "commit", "-m", "beta"])
 


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/VOL-84

Assert that changing a branch will restart the container by making the memorydiskserver read a value on startup, and then using it to write two branches and switch between them.

These are tests for the Python implementation so that the golang implementation can then be made to pass in another branch.