### PR TITLE
[VOL-91] configure fast finish in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   allow_failures:
     - env: "DOCKER_VERSION=experimental RUN_TESTS=test-dvol-python-acceptance"
     - env: "DOCKER_VERSION=experimental RUN_TESTS=test-dvol-golang-acceptance"
+  fast_finish: true
 
 services:
   - docker


### PR DESCRIPTION
Configure Travis for fast finish - travis should report success before running builds marked with allow_failures