### PR TITLE
[VOL-93] Test docker volumes removed

### DIFF
--- a/dvol_python/test_plugin.py
+++ b/dvol_python/test_plugin.py
@@ -206,11 +206,11 @@ class VoluminousTests(TestCase):
         """
         def cleanup():
             try:
-                run(["docker", "rm", "_fv", "volume_remove_test"])
+                run(["docker", "rm", "-fv", "volume_remove_test"])
             except:
                 pass
             try:
-                run(["docker", "rm", "_fv", "volume_remove_test_error"])
+                run(["docker", "rm", "-fv", "volume_remove_test_error"])
             except:
                 pass
             try:

--- a/dvol_python/test_plugin.py
+++ b/dvol_python/test_plugin.py
@@ -199,7 +199,6 @@ class VoluminousTests(TestCase):
         self.assertEqual(current_value, "Value: alpha")
 
     @skip_if_python_version # The Python implementation is broken
-    @skip_if_go_version # Remove me when implemented in Go
     def test_docker_volumes_removed(self):
         """
         When a dvol volume is removed, you can implicitly create a new volume
@@ -207,15 +206,20 @@ class VoluminousTests(TestCase):
         """
         def cleanup():
             try:
-                run(["docker", "rm", "-fv", "volume_remove_test"])
+                run(["docker", "rm", "_fv", "volume_remove_test"])
             except:
                 pass
             try:
-                run(["docker", "rm", "-fv", "volume_remove_test_error"])
+                run(["docker", "rm", "_fv", "volume_remove_test_error"])
             except:
                 pass
             try:
-                run(["docker", "volume", "rm", "volume_remove_test"])
+                run(["docker", "volume", "rm", "volume-remove-test"])
+                pass
+            except:
+                pass
+            try:
+                run([DVOL, "rm", "-f", "volume-remove-test"])
                 pass
             except:
                 pass
@@ -224,15 +228,15 @@ class VoluminousTests(TestCase):
 
         # Start a new container
         run(["docker", "run", "--name", "volume_remove_test", "-v",
-            "volume_remove_test:/data", "--volume-driver", "dvol", "-d",
+            "volume-remove-test:/data", "--volume-driver", "dvol", "-d",
             "busybox", "true"])
 
         # Remove the volume
-        run([DVOL, "rm", "-f", "volume_remove_test"])
+        run([DVOL, "rm", "-f", "volume-remove-test"])
 
         # Start a new container on the same volume and expect an error
         run(["docker", "run", "--name", "volume_remove_test_error", "-v",
-            "volume_remove_test:/data", "--volume-driver", "dvol", "-d",
+            "volume-remove-test:/data", "--volume-driver", "dvol", "-d",
             "busybox", "true"])
 
     @skip_if_python_version


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/VOL-93

This branch adds functionality to implicitly create a volume when asked to mount it, even if it has been disappeared. This is a workflow convenience that was present in the Python implementation (sometimes!) and so official support for it is needed in the Go implementation.