### PR TITLE
[VOL-92] dvol reset in Go

### DIFF
--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -381,7 +381,6 @@ class VoluminousTests(TestCase):
                 expectedLines, actualLines):
             self.assertTrue(actual.startswith(expected))
 
-    @skip_if_go_version
     def test_reset(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
@@ -402,7 +401,6 @@ class VoluminousTests(TestCase):
         self.assertEqual(volume.child("branches").child("master")
                 .child("file.txt").getContent(), "alpha")
 
-    @skip_if_go_version
     def test_reset_HEAD(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
@@ -419,7 +417,6 @@ class VoluminousTests(TestCase):
         self.assertEqual(volume.child("branches").child("master")
                 .child("file.txt").getContent(), "alpha")
 
-    @skip_if_go_version
     def test_reset_HEAD_multiple_commits(self):
         # assert that the correct (latest) commit is rolled back to
         dvol = VoluminousOptions()
@@ -444,7 +441,6 @@ class VoluminousTests(TestCase):
         self.assertEqual(volume.child("branches").child("master")
                 .child("file.txt").getContent(), "alpha")
 
-    @skip_if_go_version
     def test_reset_HEAD_hat_multiple_commits(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])

--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -441,6 +441,7 @@ class VoluminousTests(TestCase):
         self.assertEqual(volume.child("branches").child("master")
                 .child("file.txt").getContent(), "alpha")
 
+    @skip_if_go_version
     def test_reset_HEAD_hat_multiple_commits(self):
         dvol = VoluminousOptions()
         dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "init", "foo"])
@@ -475,7 +476,6 @@ class VoluminousTests(TestCase):
             "log"])
         actual = dvol.voluminous.getOutput()[-1]
         self.assertEqual(len(actual.split("\n")), 6) # 6 lines = 1 commit
-
         # only old exists
         self.assertTrue(volume.child("commits").child(oldCommit).exists())
         self.assertFalse(volume.child("commits").child(newCommit).exists())

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -192,12 +192,24 @@ func (dvol *DvolAPI) AllVolumes() ([]DvolVolume, error) {
 }
 
 func (dvol *DvolAPI) Commit(activeVolume, activeBranch, commitMessage string) (string, error) {
-    // returns a CommitId which is a string 40 byte UUID
+	// returns a CommitId which is a string 40 byte UUID
 	commitId, err := dvol.dl.Snapshot(activeVolume, activeBranch, commitMessage)
 	if err != nil {
 		return "", err
 	}
 	return string(commitId), nil
+}
+
+func (dvol *DvolAPI) ResetActiveVolume(commit string) error {
+	activeVolume, err := dvol.ActiveVolume()
+	if err != nil {
+		return err
+	}
+	activeBranch, err := dvol.ActiveBranch(activeVolume)
+	if err := dvol.dl.ResetVolume(commit, activeVolume, activeBranch); err != nil {
+		return err
+	}
+	return nil
 }
 
 /*

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ClusterHQ/dvol/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+var hardReset bool
+
+func NewCmdReset(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		// TODO: Improve the usage string to include a volume name to remove
+		Use:   "reset",
+		Short: "Reset active branch to a commit, destroying later unreferenced commits",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := resetVolume(cmd, args, out)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&hardReset, "hard", "", false, "Force removal of newer data (must be set)")
+	return cmd
+}
+
+func resetVolume(cmd *cobra.Command, args []string, out io.Writer) error {
+	dvol := api.NewDvolAPI(basePath)
+	commit := args[0]
+	if err := dvol.ResetActiveVolume(commit); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -30,6 +30,9 @@ func NewCmdReset(out io.Writer) *cobra.Command {
 
 func resetVolume(cmd *cobra.Command, args []string, out io.Writer) error {
 	dvol := api.NewDvolAPI(basePath)
+	if len(args) != 1 {
+		return fmt.Errorf("Must specify one and only one commit identifier.")
+	}
 	commit := args[0]
 	if err := dvol.ResetActiveVolume(commit); err != nil {
 		return err

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	RootCmd.AddCommand(NewCmdList(os.Stdout))
 	RootCmd.AddCommand(NewCmdCheckout(os.Stdout))
 	RootCmd.AddCommand(NewCmdCommit(os.Stdout))
+	RootCmd.AddCommand(NewCmdReset(os.Stdout))
 
 	RootCmd.PersistentFlags().StringVarP(&basePath, "path", "p", "/var/lib/dvol/volumes",
 		"The name of the directory to use")

--- a/pkg/datalayer/datalayer.go
+++ b/pkg/datalayer/datalayer.go
@@ -86,9 +86,13 @@ func (dl *DataLayer) ResetVolume(commit, volumeName, variantName string) error {
 	if err := os.RemoveAll(variantPath); err != nil {
 		return err
 	}
-	dl.copyFiles(commitPath, variantPath)
-	dl.destroyNewerCommits(commitId, volumeName, variantName)
-	// TODO: Release lock
+	if err := dl.copyFiles(commitPath, variantPath); err != nil {
+		return err
+	}
+	if err := dl.destroyNewerCommits(commitId, volumeName, variantName); err != nil {
+		return err
+	}
+	// TODO: Release lock (should be deferred actually)
 	return err
 }
 
@@ -244,43 +248,66 @@ func (dl *DataLayer) resolveNamedCommitOnBranch(commit, volumeName, variantName 
 	return commits[len(commits)-1-offset].Id, err
 }
 
-func (dl *DataLayer) destroyNewerCommits(commitId CommitId, volumeName, variantName string) error {
-	// TODO: This should really be atomic but it's okay for now
-	commits, err := dl.ReadCommitsForBranch(volumeName, variantName)
-	if err != nil {
-		return err
-	}
+func indexOfCommit(commitId CommitId, commits []Commit) int {
 	commitIdx := -1
 	for idx, commit := range commits {
 		if commit.Id == commitId {
 			commitIdx = idx
 		}
 	}
-	if commitIdx < 0 {
-		return fmt.Errorf("Could not find commit with ID %s\n", string(commitId))
-	}
-	remainingCommits := commits[:commitIdx+1]
-	destroyCommits := commits[commitIdx+1:]
-	allVariants, err := dl.AllVariants(volumeName)
+	return commitIdx
+}
+
+func (dl *DataLayer) allCommitsNotInVariant(volumeName, variantName string) (map[CommitId]Commit, error) {
 	allCommits := make(map[CommitId]Commit)
+	allVariants, err := dl.AllVariants(volumeName)
+	if err != nil {
+		return allCommits, err
+	}
 	for _, variant := range allVariants {
 		if variant != variantName {
 			variantCommits, err := dl.ReadCommitsForBranch(volumeName, variant)
 			if err != nil {
-				return err
+				return allCommits, err
 			}
 			for _, commit := range variantCommits {
 				allCommits[commit.Id] = commit
 			}
 		}
 	}
-	for _, commit := range destroyCommits {
-		if _, ok := allCommits[commit.Id]; ok {
+	return allCommits, nil
+}
+
+func (dl *DataLayer) destroyCommits(volumeName string, destroy []Commit, all map[CommitId]Commit) error {
+	for _, commit := range destroy {
+		if _, ok := all[commit.Id]; ok {
 			commitPath := dl.commitPath(volumeName, commit.Id)
 			if err := os.RemoveAll(commitPath); err != nil {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func (dl *DataLayer) destroyNewerCommits(commitId CommitId, volumeName, variantName string) error {
+	// TODO: This should really be atomic but it's okay for now
+	commits, err := dl.ReadCommitsForBranch(volumeName, variantName)
+	if err != nil {
+		return err
+	}
+	commitIdx := indexOfCommit(commitId, commits)
+	if commitIdx < 0 {
+		return fmt.Errorf("Could not find commit with ID %s\n", string(commitId))
+	}
+	remainingCommits := commits[:commitIdx+1]
+	destroyCommits := commits[commitIdx+1:]
+	allCommits, err := dl.allCommitsNotInVariant(volumeName, variantName)
+	if err != nil {
+		return err
+	}
+	if err := dl.destroyCommits(volumeName, destroyCommits, allCommits); err != nil {
+		return err
 	}
 	if err := dl.WriteCommitsForBranch(volumeName, variantName, remainingCommits); err != nil {
 		return err

--- a/pkg/datalayer/datalayer.go
+++ b/pkg/datalayer/datalayer.go
@@ -83,10 +83,12 @@ func (dl *DataLayer) ResetVolume(commit, volumeName, variantName string) error {
 		return err
 	}
 	// TODO: Acquire lock
+	if err := os.RemoveAll(variantPath); err != nil {
+		return err
+	}
 	dl.copyFiles(commitPath, variantPath)
 	dl.destroyNewerCommits(commitId, volumeName, variantName)
 	// TODO: Release lock
-
 	return err
 }
 
@@ -239,7 +241,7 @@ func (dl *DataLayer) resolveNamedCommitOnBranch(commit, volumeName, variantName 
 	}
 	// Read the commit database
 	commits, err := dl.ReadCommitsForBranch(volumeName, variantName)
-	return commits[-offset].Id, err
+	return commits[len(commits)-1-offset].Id, err
 }
 
 func (dl *DataLayer) destroyNewerCommits(commitId CommitId, volumeName, variantName string) error {
@@ -257,8 +259,8 @@ func (dl *DataLayer) destroyNewerCommits(commitId CommitId, volumeName, variantN
 	if commitIdx < 0 {
 		return fmt.Errorf("Could not find commit with ID %s\n", string(commitId))
 	}
-	remainingCommits := commits[:commitIdx]
-	destroyCommits := commits[commitIdx:]
+	remainingCommits := commits[:commitIdx+1]
+	destroyCommits := commits[commitIdx+1:]
 	allVariants, err := dl.AllVariants(volumeName)
 	allCommits := make(map[CommitId]Commit)
 	for _, variant := range allVariants {


### PR DESCRIPTION
Implements `dvol reset` in Go and makes pass:

- test_reset
- test_reset_HEAD
- test_reset_HEAD_multiple_commits

test_reset_HEAD_hat_multiple_commits does pass if you remove any references to dvol log in it, which will need to be implemented in another branch.