### PR TITLE
Create 'master' on implicit volume creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ venv/
 *.egg-info
 
 .DS_Store
+cover.out
+dvol
+dvol-docker-plugin
+memorydiskserver
+dvol.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ cache:
 
 before_install:
   # Get packaging tools that can use and cache wheels.
-  - "pip install --user `whoami` --upgrade pip>=7"
+  - "pip install --user `whoami` --upgrade pip>=7 setuptools>=11.3"
   - "pip install --user `whoami` wheel"
   # 'upgrade' docker-engine to specific version
   - scripts/build-travis-install-docker.sh ${DOCKER_VERSION}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To compile dvol:
 $ make build
 ```
 
-To run the tests:
+To run the unit tests:
 
 ```sh
 $ make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN         apt-get -qy update && \
             apt-get -qy install libyaml-dev && \
             apt-get -qy install libffi-dev && \
             apt-get -qy install libssl-dev && \
+            pip install --upgrade pip setuptools && \
 # Pre-install some requirements to make the next step hopefully faster
             pip install twisted==14.0.0 treq==0.2.1 service_identity pycrypto pyrsistent pyyaml==3.10
 

--- a/cmd/dvol-docker-plugin/dvol-docker-plugin.go
+++ b/cmd/dvol-docker-plugin/dvol-docker-plugin.go
@@ -148,10 +148,12 @@ func main() {
 		err = dvol.SwitchVolume(name)
 		if err != nil {
 			writeResponseErr(err, w)
+			return
 		}
 		_, err = dvol.ActiveVolume()
 		if err != nil {
 			writeResponseErr(err, w)
+			return
 		}
 		path := dvol.VolumePath(name)
 

--- a/cmd/dvol-docker-plugin/dvol-docker-plugin.go
+++ b/cmd/dvol-docker-plugin/dvol-docker-plugin.go
@@ -106,6 +106,14 @@ func main() {
 				writeResponseErr(fmt.Errorf("Could not create volume %s: %v", name, err), w)
 				return
 			}
+
+			// XXX: This is copied from the code for `dvol init`. Reuse that code.
+			// XXX: There's already a constant for default branch. Use that.
+			err = dvol.CreateBranch(name, "master")
+			if err != nil {
+				writeResponseErr(fmt.Errorf("Error creating branch"), w)
+				return
+			}
 		}
 		writeResponseOK(w)
 	})

--- a/dvol_python/test_plugin.py
+++ b/dvol_python/test_plugin.py
@@ -281,11 +281,12 @@ class VoluminousTests(TestCase):
         """
         ``docker run`` with the dvol volume driver creates a master branch.
         """
-        # XXX: This is a) duplicated, b) dangerous, as it masks real errors.
         volume_name = 'docker-volume-implicit-creation-test'
         volume_directory = "/data"
         docker_volume_arg = '%s:/%s' % (volume_name, volume_directory)
 
+        # XXX: This is a) duplicated, b) dangerous, as the bare `except` masks
+        # real errors.
         def cleanup():
             try:
                 run(["docker", "volume", "rm", volume_name])


### PR DESCRIPTION
docker creates a dvol volume implicitly when using the dvol volume driver. Up until now, that created volume did not have a branch created, which means that various `dvol` commands would fail unexpectedly.

This PR fixes that by copying the code from `init` into the `VolumeDriver.Create` routine.

Also includes a few small, unrelated cleanups:

* ignore build artifacts
* abort `Mount` on error
* clarify that `make test` is for unit tests, not acceptance tests