### PR TITLE
[VOL-138] Read and save config

### DIFF
--- a/dvol_python/test_dvol.py
+++ b/dvol_python/test_dvol.py
@@ -610,3 +610,14 @@ class VoluminousTests(TestCase):
             output = error.original.output
         self.assertIn("Error", output)
         self.assertIn("foo/bar", output)
+
+    @skip_if_python_version
+    def test_get_set_config(self):
+        """
+        A configuration key can be set and then retrieved.
+        """
+        dvol = VoluminousOptions()
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "config", "user.name", "alice"])
+        dvol.parseOptions(ARGS + ["-p", self.tmpdir.path, "config", "user.name"])
+        self.assertEqual(dvol.voluminous.getOutput()[-1],
+            "alice")

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -40,11 +40,17 @@ func NewCmdConfig(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+func initConfig() {
+	viper.SetConfigName("config")
+	viper.AddConfigPath(basePath)
+	viper.ReadInConfig()
+}
+
 func dispatchConfig(args []string, out io.Writer) error {
 	if len(args) == 0 {
 		return errors.New("Not enough arguments")
 	} else if len(args) == 1 {
-		return errors.New("Any operation other than setting a value is not implemented yet")
+		return getConfigValue(args[0], out)
 	} else if len(args) == 2 {
 		return setConfigValue(args[0], args[1])
 	} else {
@@ -52,12 +58,17 @@ func dispatchConfig(args []string, out io.Writer) error {
 	}
 }
 
-func initConfig() {
-	viper.SetConfigName("config")
-	viper.AddConfigPath(basePath)
-	viper.ReadInConfig()
-}
+func getConfigValue(key string, out io.Writer) error {
+	if !isValidKey(key) {
+		return fmt.Errorf("'%s' is not a valid configuration key", key)
+	}
 
+	value := viper.GetString(key)
+	if _, err := io.WriteString(out, value + "\n"); err != nil { 
+		return err
+	}
+	return nil
+}
 func setConfigValue(key, value string) error {
 	if !isValidKey(key) {
 		return fmt.Errorf("'%s' is not a valid configuration key", key)

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -15,7 +15,7 @@ import (
 
 type Config struct {
 	// Used to marshal the configuration into YAML
-	UserName string `mapstructure:"user.name" yaml:"user.name"`
+	UserName  string `mapstructure:"user.name" yaml:"user.name"`
 	UserEmail string `mapstructure:"user.email" yaml:"user.email"`
 }
 
@@ -61,7 +61,7 @@ func getConfigValue(key string, out io.Writer) error {
 	if len(value) > 0 {
 		value += "\n"
 	}
-	if _, err := io.WriteString(out, value); err != nil { 
+	if _, err := io.WriteString(out, value); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -40,6 +40,21 @@ func NewCmdConfig(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+func initialiseConfig() error {
+	viper.SetConfigFile(configPath())
+	if err := viper.ReadInConfig(); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func configPath() string {
+	// Return the configuration file path
+	return path.Join(basePath, "config.yml")
+}
+
 func dispatchConfig(args []string, out io.Writer) error {
 	if len(args) == 0 {
 		return errors.New("Not enough arguments")
@@ -91,12 +106,14 @@ func saveConfig() error {
 		return err
 	}
 
-	configPath := path.Join(basePath, "config.yml")
+	configPath := configPath()
 	file, err := ioutil.TempFile(basePath, "dvol_config")
 	if err != nil {
 		return err
 	}
-	os.Chmod(file.Name(), 0600)
+	if err := os.Chmod(file.Name(), 0600); err != nil {
+		return err
+	}
 	if _, err := file.Write(yamlConfig); err != nil {
 		os.Remove(file.Name())
 		return err

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -40,12 +40,6 @@ func NewCmdConfig(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func initConfig() {
-	viper.SetConfigName("config")
-	viper.AddConfigPath(basePath)
-	viper.ReadInConfig()
-}
-
 func dispatchConfig(args []string, out io.Writer) error {
 	if len(args) == 0 {
 		return errors.New("Not enough arguments")

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -98,7 +98,7 @@ func saveConfig() error {
 	}
 
 	configPath := path.Join(basePath, "config.yml")
-	file, err := ioutil.TempFile(os.TempDir(), "dvol_config")
+	file, err := ioutil.TempFile(basePath, "dvol_config")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -64,7 +64,10 @@ func getConfigValue(key string, out io.Writer) error {
 	}
 
 	value := viper.GetString(key)
-	if _, err := io.WriteString(out, value + "\n"); err != nil { 
+	if len(value) > 0 {
+		value += "\n"
+	}
+	if _, err := io.WriteString(out, value); err != nil { 
 		return err
 	}
 	return nil

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -107,6 +107,5 @@ func saveConfig() error {
 		os.Remove(file.Name())
 		return err
 	}
-	os.Rename(file.Name(), configPath)
-	return nil
+	return os.Rename(file.Name(), configPath)
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -10,6 +10,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+type Config struct {
+	// Used to marshal the configuration into YAML
+	UserName string `mapstructure:"user.name" yaml:"user.name"`
+	UserEmail string `mapstructure:"user.email" yaml:"user.email"`
+}
+
 func isValidKey(key string) bool {
 	switch key {
 	case
@@ -37,16 +43,23 @@ func dispatchConfig(args []string, out io.Writer) error {
 	} else if len(args) == 1 {
 		return errors.New("Any operation other than setting a value is not implemented yet")
 	} else if len(args) == 2 {
-		return setConfigValue(args[0], args[1], out)
+		return setConfigValue(args[0], args[1])
 	} else {
 		return errors.New("Too many arguments")
 	}
 }
 
-func setConfigValue(key, value string, out io.Writer) error {
+func setConfigValue(key, value string) error {
 	if !isValidKey(key) {
 		return fmt.Errorf("'%s' is not a valid configuration key", key)
 	}
+
 	viper.Set(key, value)
 	return nil
+}
+
+func unmarshalConfig() (Config, error) {
+	var C Config
+	err := viper.Unmarshal(&C)
+	return C, err
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"reflect"
 	"testing"
 
@@ -41,6 +40,14 @@ func TestTooManyArguments(t *testing.T) {
 		t.Error("No error")
 	} else if err.Error() != "Too many arguments" {
 		t.Error("Unexpected error:", err)
+	}
+}
+
+func TestMissingConfig(t *testing.T) {
+	// Initialising the configuration when it is missing is not an error
+	os.Remove(configPath())
+	if err := initialiseConfig(); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -116,7 +123,7 @@ func TestConfigFileMode(t *testing.T) {
 		t.Error(err)
 	}
 
-	configPath := path.Join(basePath, "config.yml")
+	configPath := configPath()
 	stat, err := os.Stat(configPath)
 	if err != nil {
 		t.Error(err)
@@ -134,7 +141,7 @@ func TestConfigReadFromDisk(t *testing.T) {
 		t.Error(err)
 	}
 
-	initConfig()
+	initialiseConfig()
 
 	value := viper.GetString("user.name")
 	if value != "alice" {

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 func TestCannotGetYet(t *testing.T) { // TODO: Implement get and then remove this
@@ -62,5 +65,42 @@ func TestSetUnknownValue(t *testing.T) {
 		t.Error("No error")
 	} else if err.Error() != "'garbage' is not a valid configuration key" {
 		t.Error("Unexpected error:", err)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	// The config can be unmarshaled into a struct
+	if err := setConfigValue("user.name", "alice"); err != nil {
+		t.Error(err)
+	}
+
+	config, err := unmarshalConfig()
+	if err != nil {
+		t.Error(err)
+	}
+	expected := Config{
+		UserName: "alice",
+	}
+	if !reflect.DeepEqual(config, expected) {
+		t.Error("Not equal:", config, expected)
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	// A Config struct can be marshaled into YAML bytes
+	config := Config{
+		UserName: "alice",
+		UserEmail: "alice@acme.co",
+	}
+	expected := []byte(`user.name: alice
+user.email: alice@acme.co
+`)
+
+	out, err := yaml.Marshal(config)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(out, expected) {
+		t.Error("\nExpected:\t", expected, "\nGot:\t\t", out)
 	}
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -145,6 +145,11 @@ func TestConfigReadFromDisk(t *testing.T) {
 func TestConfigGetOutput(t *testing.T) {
 	// Passing only a single argument results in the configuration key value
 	// being printed to Stdout followed by a newline.
+	viper.Reset()
+	if err := setConfigValue("user.name", "alice"); err != nil {
+		t.Error(err)
+	}
+
 	args := []string{"user.name"}
 	w := new(bytes.Buffer)
 
@@ -154,6 +159,23 @@ func TestConfigGetOutput(t *testing.T) {
 
 	outString := w.String()
 	if outString != "alice\n" {
+		t.Errorf("Unexpected output, got: %v, expected: %v", outString, "alice\n")
+	}
+}
+
+func TestConfigGetOutputEmpty(t *testing.T) {
+	// Passing only a single argument results in the configuration key value
+	// being printed to Stdout followed by a newline. If the key is unset or empty, print nothing.
+	viper.Reset()
+	args := []string{"user.name"}
+	w := new(bytes.Buffer)
+
+	if err := dispatchConfig(args, w); err != nil {
+		t.Error(err)
+	}
+
+	outString := w.String()
+	if outString != "" {
 		t.Errorf("Unexpected output, got: %v, expected: %v", outString, "alice\n")
 	}
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -137,7 +138,7 @@ func TestConfigFileMode(t *testing.T) {
 	}
 }
 
-func TestConfigRead(t *testing.T) {
+func TestConfigReadFromDisk(t *testing.T) {
 	// The config is readable after being written
 	viper.Reset()
 	if err := setConfigValue("user.name", "alice"); err != nil {
@@ -149,5 +150,26 @@ func TestConfigRead(t *testing.T) {
 	value := viper.GetString("user.name")
 	if value != "alice" {
 		t.Error("Incorrect value retrieved, got:", value)
+	}
+}
+
+func TestConfigGetOutput(t *testing.T) {
+	// Passing only a single argument results in the configuration key value
+	// being printed to Stdout followed by a newline.
+	args := []string{"user.name"}
+	var w io.ReadWriteSeeker
+	var out []byte
+
+	if err := dispatchConfig(args, w); err != nil {
+		t.Error(err)
+	}
+	_, err := w.Seek(0, 0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	io.ReadFull(w, out)
+	if string(out) != "alice\n" {
+		t.Errorf("Unexpected output, got: %v, expected: %v", string(out), "alice\n")
 	}
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -23,16 +22,6 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(basePath)
 	os.Exit(m.Run())
-}
-
-func TestCannotGetYet(t *testing.T) { // TODO: Implement get and then remove this
-	args := []string{"user.name"}
-
-	if err := dispatchConfig(args, os.Stdout); err == nil {
-		t.Error("No error")
-	} else if err.Error() != "Any operation other than setting a value is not implemented yet" {
-		t.Error("Unexpected error:", err)
-	}
 }
 
 func TestNotEnoughArguments(t *testing.T) {
@@ -157,19 +146,14 @@ func TestConfigGetOutput(t *testing.T) {
 	// Passing only a single argument results in the configuration key value
 	// being printed to Stdout followed by a newline.
 	args := []string{"user.name"}
-	var w io.ReadWriteSeeker
-	var out []byte
+	w := new(bytes.Buffer)
 
 	if err := dispatchConfig(args, w); err != nil {
 		t.Error(err)
 	}
-	_, err := w.Seek(0, 0)
-	if err != nil {
-		t.Error(err)
-	}
 
-	io.ReadFull(w, out)
-	if string(out) != "alice\n" {
-		t.Errorf("Unexpected output, got: %v, expected: %v", string(out), "alice\n")
+	outString := w.String()
+	if outString != "alice\n" {
+		t.Errorf("Unexpected output, got: %v, expected: %v", outString, "alice\n")
 	}
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -93,7 +93,7 @@ func TestUnmarshal(t *testing.T) {
 func TestMarshal(t *testing.T) {
 	// A Config struct can be marshaled into YAML bytes
 	config := Config{
-		UserName: "alice",
+		UserName:  "alice",
 		UserEmail: "alice@acme.co",
 	}
 	expected := []byte(`user.name: alice

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -2,13 +2,27 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 	"reflect"
 	"testing"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
+
+func TestMain(m *testing.M) {
+	var err error
+	basePath, err = ioutil.TempDir("", "dvol_config_test")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+	defer os.RemoveAll(basePath)
+	os.Exit(m.Run())
+}
 
 func TestCannotGetYet(t *testing.T) { // TODO: Implement get and then remove this
 	args := []string{"user.name"}
@@ -102,5 +116,38 @@ user.email: alice@acme.co
 	}
 	if !bytes.Equal(out, expected) {
 		t.Error("\nExpected:\t", expected, "\nGot:\t\t", out)
+	}
+}
+
+func TestConfigFileMode(t *testing.T) {
+	// The config is saved as readable and writeable by the user only
+	viper.Reset()
+	if err := setConfigValue("user.name", "alice"); err != nil {
+		t.Error(err)
+	}
+
+	configPath := path.Join(basePath, "config.yml")
+	stat, err := os.Stat(configPath)
+	if err != nil {
+		t.Error(err)
+	}
+	perm := stat.Mode().Perm()
+	if perm != 0600 {
+		t.Error("Incorrect permissions", perm, "on", configPath)
+	}
+}
+
+func TestConfigRead(t *testing.T) {
+	// The config is readable after being written
+	viper.Reset()
+	if err := setConfigValue("user.name", "alice"); err != nil {
+		t.Error(err)
+	}
+
+	initConfig()
+
+	value := viper.GetString("user.name")
+	if value != "alice" {
+		t.Error("Incorrect value retrieved, got:", value)
 	}
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ClusterHQ/dvol/pkg/api"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var basePath string
@@ -29,7 +30,7 @@ and come back to it later.`,
 }
 
 func init() {
-	// cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig)
 	RootCmd.AddCommand(NewCmdBranch(os.Stdout))
 	RootCmd.AddCommand(NewCmdCheckout(os.Stdout))
 	RootCmd.AddCommand(NewCmdConfig(os.Stdout))
@@ -46,10 +47,15 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&disableDockerIntegration,
 		"disable-docker-integration", false, "Do not attempt to list/stop/start"+
 			" docker containers which are using dvol volumes")
+}
 
+func initConfig() {
 	if _, err := os.Stat(basePath); err != nil {
 		os.MkdirAll(basePath, 0600)
 	}
 
-	initConfig()
+	viper.SetConfigName("config")
+	viper.AddConfigPath(basePath)
+	viper.ReadInConfig()
 }
+

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -47,5 +47,9 @@ func init() {
 		"disable-docker-integration", false, "Do not attempt to list/stop/start"+
 			" docker containers which are using dvol volumes")
 
+	if _, err := os.Stat(basePath); err != nil {
+		os.MkdirAll(basePath, 0600)
+	}
+
 	initConfig()
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/ClusterHQ/dvol/pkg/api"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var basePath string
@@ -21,16 +21,24 @@ var RootCmd = &cobra.Command{
 dvol lets you commit, reset and branch the containerized databases
 running on your laptop so you can easily save a particular state
 and come back to it later.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Make the basePath directory if it does not exist
+		if _, err := os.Stat(basePath); err != nil {
+			if err := os.MkdirAll(basePath, 0600); err != nil {
+				return fmt.Errorf("Could not create dvol directory %s: %v", basePath, err)
+			}
+		}
+
 		dvolAPIOptions = api.DvolAPIOptions{
 			BasePath:                 basePath,
 			DisableDockerIntegration: disableDockerIntegration,
 		}
+
+		return initialiseConfig()
 	},
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
 	RootCmd.AddCommand(NewCmdBranch(os.Stdout))
 	RootCmd.AddCommand(NewCmdCheckout(os.Stdout))
 	RootCmd.AddCommand(NewCmdConfig(os.Stdout))
@@ -47,14 +55,4 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&disableDockerIntegration,
 		"disable-docker-integration", false, "Do not attempt to list/stop/start"+
 			" docker containers which are using dvol volumes")
-}
-
-func initConfig() {
-	if _, err := os.Stat(basePath); err != nil {
-		os.MkdirAll(basePath, 0600)
-	}
-
-	viper.SetConfigName("config")
-	viper.AddConfigPath(basePath)
-	viper.ReadInConfig()
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -58,4 +58,3 @@ func initConfig() {
 	viper.AddConfigPath(basePath)
 	viper.ReadInConfig()
 }
-

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ClusterHQ/dvol/pkg/api"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var basePath string
@@ -48,7 +47,5 @@ func init() {
 		"disable-docker-integration", false, "Do not attempt to list/stop/start"+
 			" docker containers which are using dvol volumes")
 
-	viper.SetConfigName("config")
-	viper.AddConfigPath("$HOME/.dvol")
-	viper.ReadInConfig()
+	initConfig()
 }


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/VOL-138

This branch adds support for storing the configuration, reading it properly, and being able to print the configuration.

I moved the configuration location into `basePath` after a discussion with Luke (multi-user support isn't here yet).
