### PR TITLE
Remove go vet as a dependency as it is included in Go these days.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-go: build
 	&& scripts/verify-tests.sh
 
 # 'verify' ensures your golang code passes 'the basics'
-# locally before committing e.g. gofmt, go etc
+# locally before committing e.g. gofmt, go vet etc
 verify:
 	scripts/verify-preflight.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-go: build
 	&& scripts/verify-tests.sh
 
 # 'verify' ensures your golang code passes 'the basics'
-# locally before committing e.g. gofmt, go vet etc
+# locally before committing e.g. gofmt, go etc
 verify:
 	scripts/verify-preflight.sh
 
@@ -25,16 +25,13 @@ bootstrap: go-bootstrap python-bootstrap
 
 # 'go-bootstrap' installs all of the golang tools required by dvol
 # remember to add {GOPATH}/bin to your Path
-go-bootstrap: godep cover vet goimports gotestcover
+go-bootstrap: godep cover goimports gotestcover
 
 godep:
 	go get github.com/tools/godep
 
 cover:
 	go get golang.org/x/tools/cmd/cover
-
-vet:
-	go get golang.org/x/tools/cmd/vet
 
 gotestcover:
 	go get github.com/pierrre/gotestcover


### PR DESCRIPTION
https://golang.org/cmd/vet/

This fixes current builds as the `go vet` repository has been removed.